### PR TITLE
interactive styles update

### DIFF
--- a/src/diagrams/details-illustration.svelte
+++ b/src/diagrams/details-illustration.svelte
@@ -13,7 +13,7 @@
 
 </style>
 
-<div>
+<div class="interactive-container">
     <Title
         titleText="[TK]."
         subtitleText="[TK]."

--- a/src/diagrams/details-math.svelte
+++ b/src/diagrams/details-math.svelte
@@ -21,7 +21,7 @@
 
 </style>
 
-<div>
+<div class="interactive-container">
 
     <Title
         titleText="Enhancing mathematics design with annotation and interactivity."

--- a/src/diagrams/details-text.svelte
+++ b/src/diagrams/details-text.svelte
@@ -53,7 +53,7 @@
 
 </style>
 
-<div>
+<div class="interactive-container">
 
     <Title
         titleText="The Universal Approximation Theorem in 3 levels of detail."

--- a/src/diagrams/details-vis.svelte
+++ b/src/diagrams/details-vis.svelte
@@ -41,7 +41,7 @@
     }
 </style>
 
-<div>
+<div class="interactive-container">
 
     <Title
         titleText="[TK]."

--- a/src/diagrams/horse.svelte
+++ b/src/diagrams/horse.svelte
@@ -2,7 +2,7 @@
     import { onDestroy } from 'svelte';
     import Title from './title.svelte'
 
-    let frameNumber = 1;
+    let frameNumber = 2;
     let isPlaying = false;
 
     const numOfFrames = 11;
@@ -16,7 +16,7 @@
             playInterval = setInterval(() => {
                     frameNumber = frameNumber % numOfFrames;
                     frameNumber += 1;
-                }, 100);            
+                }, 100);
         }
     }
 
@@ -30,12 +30,12 @@
         frameNumber = i;
     }
 
-    play();
+    // play();
 
 </script>
 
 <style>
-    
+
     #wrapper {
         margin-top: 1.5em;
         margin-bottom: 1.5em;
@@ -146,13 +146,13 @@
 
 </style>
 
-<div id="wrapper">
+<div id="wrapper" class="interactive-container">
 
     <Title
         titleText="Does a horse lift all its feet of the ground?"
         subtitleText="This interactive graphic uses user-controlled animation to illustrate this finding."
     />
-    
+
     <div id="horse-wrapper">
         <img id="horse" src="images/horse/{frameNumber}.jpg" alt="Horse running."/>
         <div id="horse-controls">

--- a/src/diagrams/simulation-vis.svelte
+++ b/src/diagrams/simulation-vis.svelte
@@ -107,7 +107,7 @@
 
 </style>
 
-<div>
+<div class="interactive-container">
 
   <Title
     titleText="Interacting with live simulations—no setup required."

--- a/src/diagrams/title.svelte
+++ b/src/diagrams/title.svelte
@@ -10,7 +10,7 @@
         font-size: 20px;
         margin-bottom: 0.25em;
         /* text-transform: uppercase */
-        color: var(--orange);
+        /* color: var(--orange); */
     }
 
     #subtitle {
@@ -30,7 +30,7 @@
 </style>
 
 <div>
-    
+
     <!-- <div style="display: flex"> -->
         <!-- <img src="images/pointer.svg" alt="Pointer: interactive diagram."> -->
         <div id="title">{titleText}</div>

--- a/src/diagrams/you-draw-it.svelte
+++ b/src/diagrams/you-draw-it.svelte
@@ -141,7 +141,7 @@
 
 </style>
 
-<div>
+<div class="interactive-container">
 
   <Title
     titleText="Complete the trend for [TK]."

--- a/static/styles.css
+++ b/static/styles.css
@@ -71,6 +71,13 @@ d-figure>figure {
   margin-bottom: 0em !important;
 }
 
+.interactive-container {
+  background-color: hsl(0, 0%, 97%);
+  border: 1px solid hsla(0, 0%, 0%, 0.1);
+  /* border-bottom: 1px solid hsla(0, 0%, 0%, 0.1); */
+  padding: 1em 2em;
+}
+
 @media (max-width: 1178px) {
   .video-d-figure {
     float: none;


### PR DESCRIPTION
Gives all the interstitial interactives a light gray background (matching the "applications" box). I think this helps differentiate them while keeping things consistent and breaking up the text a bit more.

While I was playing around I also changed the initial config of the horse graphic a little bit so that it starts on a still image where all feet are off the ground. 


<img width="1257" alt="Screen Shot 2020-04-01 at 1 02 24 PM" src="https://user-images.githubusercontent.com/1074773/78181397-27441880-7419-11ea-8509-ed5e71c0fab7.png">
