### PR TITLE
trying other teaser styles

### DIFF
--- a/src/diagrams/teaser.svelte
+++ b/src/diagrams/teaser.svelte
@@ -8,7 +8,7 @@
         --outerBorder: 1px;
         --innerBorder: 0px;
 
-        grid-column: middle;
+        grid-column: text;
         display: grid;
         grid-template-columns: repeat(5, 1fr);
         grid-gap: 1em;
@@ -21,7 +21,7 @@
     }
 
     a:hover {
-        transform: scale(1.04);
+        /* transform: scale(1.04); */
         /* box-shadow: 0px 1px 4px rgba(0,0,0,0.05); */
     }
 
@@ -29,18 +29,38 @@
         /* border: 1px solid var(--gray-border); */
         border-radius: var(--outerBorder);
         padding: var(--outerBorder);
-        font-weight: 600;
-        font-size: 1em;
+        font-weight: 500;
+        font-size: 0.6em;
+        line-height: 1.2;
+        min-height: 26px;
         /* color: rgba(0, 0, 0, 0.8); */
         /* height: 50px; */
         text-align: center;
-        border: solid 1px #999999;
+        /* border: solid 2px #999999; */
         padding: 0.5em;
+
+        /* color: #222222; */
+        /* border: none; */
+        border-radius: 25px;
+        padding: 0.5em 1em;
+        /* background: hsl(0, 0%, 97%); */
+        /* color: #666666; */
+        /* transition: 0.35s color; */
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
     }
 
-    :global(.blue-green) {
+    .item:hover {
+        color: #222222;
+    }
+
+    .blue-green {
         /* background: #00f260; fallback for old browsers */
-        box-shadow: 2px 2px 3px #00f260;
+        /* box-shadow: 5px 5px 0 #8AE395; */
+        /* background: #8AE395; */
+        border: solid 2px #5AD86A;
+        color: #5AD86A;
         /* background: -webkit-linear-gradient(to top right, #00f260, #0575e6); /* Chrome 10-25, Safari 5.1-6 */
         /* background: linear-gradient(to top right, #00f260, #0575e6); W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
         /* background: rgb(0, 236, 130); */
@@ -48,9 +68,12 @@
         /* -webkit-text-fill-color: transparent; */
     }
 
-    :global(.red-orange) {
+    .red-orange {
         /* background: #fc4a1a;  fallback for old browsers */
-        box-shadow: 2px 2px 3px #fc4a1a;
+        /* box-shadow: 5px 5px 0 #D1CA5B; */
+        /* background: #D1CA5B; */
+        border: solid 2px #C7BF38;
+        color: #C7BF38;
         /* background: -webkit-linear-gradient(to top, #f7b733, #fc4a1a);  /* Chrome 10-25, Safari 5.1-6 */
         /* background: linear-gradient(to top, #f7b733, #fc4a1a); W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
         /* background: rgb(0, 200, 255); */
@@ -58,9 +81,12 @@
         /* -webkit-text-fill-color: transparent; */
     }
 
-    :global(.soft-blue) {
+    .soft-blue {
         /* background: #74ebd5; fallback for old browsers */
-        box-shadow: 2px 2px 3px #74ebd5;
+        /* box-shadow: 5px 5px 0 #89E6F9; */
+        /* background: #89E6F9; */
+        border: solid 2px #73C4F5;
+        color: #73C4F5;
         /* background: -webkit-linear-gradient(to left, #74ebd5, #acb6e5); /* Chrome 10-25, Safari 5.1-6 */
         /* background: linear-gradient(to left, #74ebd5, #acb6e5); W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
         /* background: rgb(255, 106, 255); */
@@ -68,9 +94,12 @@
         /* -webkit-text-fill-color: transparent; */
     }
 
-    :global(.argon) {
+    .argon {
         /* background: #03001e; fallback for old browsers */
-        box-shadow: 2px 2px 3px #03001e;
+        /* box-shadow: 5px 5px 0 #DF80F1; */
+        /* background: #DF80F1; */
+        border: solid 2px #DF80F1;
+        color: #DF80F1;
         /* background: -webkit-linear-gradient(to bottom right, #03001e, #7303c0, #ec38bc, #fdeff9); /* Chrome 10-25, Safari 5.1-6 */
         /* background: linear-gradient(to bottom right, #03001e, #7303c0, #ec38bc, #fdeff9); W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
         /* background: rgb(255, 124, 82); */
@@ -78,9 +107,13 @@
         /* -webkit-text-fill-color: transparent; */
     }
 
-    :global(.sun) {
+
+    .sun {
         /* background: #e1eec3;  fallback for old browsers */
-        box-shadow: 2px 2px 3px #e1eec3;
+        /* box-shadow: 5px 5px 0 #E28765; */
+        /* background: #E28765; */
+        border: solid 2px #E28765;
+        color: #E28765;
         /* background: -webkit-linear-gradient(to right, #f05053, #e1eec3);  /* Chrome 10-25, Safari 5.1-6 */
         /* background: linear-gradient(to right, #f05053, #e1eec3); W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
         /* background: rgb(210, 204, 0); */
@@ -109,7 +142,7 @@
         .five { grid-column: 7/13;}
 
         .item {
-            height: 100px;
+            /* height: 100px; */
         }
 
         .inner {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -94,9 +94,7 @@
       Below, in-line videos and example interactive graphics are presented alongside this discussion to demonstrate specific techniques.
     </p>
 
-    <div class="square-wrapper"><div class="square blue-green"><div class="square-inner"></div></div></div>
-
-    <h3 id="connecting-people-and-data">Connecting People and Data</h3>
+    <h3 id="connecting-people-and-data" class="blue-green affordance ">Connecting People and Data</h3>
 
     <p>
       As visual designers are well aware, and as journalism researchers have confirmed empirically <d-cite key="greussing2019simply"></d-cite>, an audience which finds content to be aesthetically pleasing is more likely to have a positive attitude towards it. This in turn means people will spend more time engaging with content and ultimately lead to improved learning outcomes. While engagement itself may not be an end goal of most research communications, the ability to influence both audience attitude and the amount of time that is spent is a useful lever to improve learning: we know from education research that both time spent <d-cite key="fredrick1980learning"></d-cite> and emotion <d-cite key="um2012emotional"></d-cite> are predictive of learning outcomes.
@@ -136,9 +134,8 @@
       </p>
     </div>
 
-    <div class="square-wrapper"><div class="square red-orange"><div class="square-inner"></div></div></div>
 
-    <h3 id="making-systems-playful">Making Systems Playful</h3>
+    <h3 id="making-systems-playful" class="affordance red-orange">Making Systems Playful</h3>
 
     <p>
       Interactive articles utilize an underlying computational infrastructure, allowing authors editorial control over the computational processes happening on a page. This access to computation allows interactive articles to engage readers in an experience they could not have with traditional media. For example, in "Drawing Dynamic Visualizations", Victor demonstrates how an interactive visualization can allow readers to build an intuition about the behavior of a system, leading to a fundamentally different understanding of an underlying system compared to looking at a set of static equations <d-cite key="victor2013drawing"></d-cite>. These articles leverage active learning and reading, combined with critical thinking <d-cite key="adler2014read"></d-cite> to help diverse sets of people learn and explore using sandboxed models and simulations <d-cite key="victor2011explorable"></d-cite>.
@@ -186,10 +183,7 @@
       </p>
     </div>
 
-
-    <div class="square-wrapper"><div class="square soft-blue"><div class="square-inner"></div></div></div>
-
-    <h3 id="prompting-self-reflection">Prompting Self-Reflection</h3>
+    <h3 id="prompting-self-reflection" class="affordance soft-blue">Prompting Self-Reflection</h3>
 
     <p>
       Asking a student to reflect on material that they are studying and explain it back to themselves—a learning technique called self-explanation—is known to have a positive impact on learning outcomes <d-cite key="chi1989self"></d-cite>. By generating explanations and refining them as new information is obtained, it is hypothesised that a student will be more engaged with the processes which they are studying <d-cite key="chi2000self"></d-cite>. When writing for an interactive environment, components can be included which prompt readers to make a prediction or reflection about the material and cause them to engage in self-explanation <d-cite key="kim2017explaining"></d-cite>.
@@ -217,9 +211,7 @@
       </p>
     </div>
 
-    <div class="square-wrapper"><div class="square argon"><div class="square-inner"></div></div></div>
-
-    <h3 id="personalizing-reading">Personalizing Reading</h3>
+    <h3 id="personalizing-reading" class="affordance argon">Personalizing Reading</h3>
 
     <p>
       Content personalization—automatically modifying text and multimedia based on a reader’s individual features or input (e.g., demographics or location)—is a technique that has been shown to increase engagement and learning within readers <d-cite key="cordova1996intrinsic"></d-cite> and support behavioral change <d-cite key="di2006authoring"></d-cite>. The PersaLog system gives developers tools to build personalized content and presents guidelines for personalization based on user research from practicing journalists <d-cite key="adar2017persalog"></d-cite>. Other work has shown that "personalized spatial analogies," presenting distance measurements in regions where readers are geographically familiar with, help people more concretely understand new distance measurements within news stories <d-cite key="kim2016generating"></d-cite>.
@@ -244,9 +236,7 @@
     </p>
 
 
-    <div class="square-wrapper"><div class="square sun"><div class="square-inner"></div></div></div>
-
-    <h3 id="reducing-cognitive-load">Reducing Cognitive Load</h3>
+    <h3 id="reducing-cognitive-load" class="affordance sun">Reducing Cognitive Load</h3>
 
     <p>
       Authors must calibrate the detail at which to discuss ideas and content to their readers expertise and interest to not overload them. When topics become multifaceted and complex, a balance must be struck between a high-level overview of a topic and its lower-level details. One interaction technique used to prevent a cognitive overload within a reader is "details-on-demand."

--- a/static/styles.css
+++ b/static/styles.css
@@ -141,13 +141,14 @@ a.figure-number-text:hover, a.table-number-text:hover, a.video-number-text:hover
 }
 
 .square {
-  height: 20px;
-  width: 20px;
+  height: 10px;
+  width: 10px;
   margin-left: auto;
   border-radius: 1;
-  margin-top: -10px;
+  margin-top: -20px;
   /* border: solid 1px #999; */
   background: none;
+  border-radius: 50%;
 
 }
 
@@ -157,6 +158,29 @@ a.figure-number-text:hover, a.table-number-text:hover, a.video-number-text:hover
   /* background: white; */
   /* margin: 3px; */
   /* border-radius: 3px; */
+}
+
+h3.affordance {
+  /* line-height: 1.25em; */
+  /* margin: 2rem 0 1.5rem 0; */
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  padding-bottom: 1rem;
+}
+h3.affordance.blue-green {
+  border-bottom-color: #5AD86A;
+}
+h3.affordance.red-orange {
+  border-bottom-color: #C7BF38;
+}
+h3.affordance.soft-blue {
+  border-bottom-color: #73C4F5
+}
+h3.affordance.argon {
+  border-bottom-color: #DF80F1
+}
+h3.affordance.sun {
+  border-bottom-color: #E28765
 }
 
 @media (max-width: 1000px) {


### PR DESCRIPTION
Don't need to merge, but I want to address a couple things with the current header styles. I think the issues are:

1. Current design is too visually loud, it should support / be secondary to the title, but now overwhelms it
2. Current styles are too evocative of old Apple branding and it feels a little odd

This is one possibility I was working on. Basically trying to (1) make it take up less space vertically, (2) make color more subtle (3) stay inside the text column width

<img width="1426" alt="Screen Shot 2020-07-28 at 4 59 28 PM" src="https://user-images.githubusercontent.com/1074773/88741160-c2ad7780-d0f3-11ea-828a-2e24f81c3353.png">







